### PR TITLE
Unbreak for Tcl/Tk 8.6+

### DIFF
--- a/lib/editor/editor.tcl
+++ b/lib/editor/editor.tcl
@@ -873,13 +873,13 @@ class Editor {
 		bind $editor <Control-Key-Next> "break"
 		bind $editor <Control-Key-Prior> "break"
 		bind $editor <Key-Left> "
-			[bind Text <Key-Left>]
+			[bind Text <<PrevChar>>]
 			$this resetUpDownIndex
 			$this recalc_status_counter {}
 			$this rightPanel_adjust \[expr {int(\[%W index insert\])}\]
 			break"
 		bind $editor <Key-Right> "
-			[bind Text <Key-Right>]
+			[bind Text <<NextChar>>]
 			$this resetUpDownIndex
 			$this recalc_status_counter {}
 			$this rightPanel_adjust \[expr {int(\[%W index insert\])}\]

--- a/lib/main.tcl
+++ b/lib/main.tcl
@@ -80,7 +80,7 @@ set LIBRARIES_TO_LOAD {
 	{Itcl		3.4}
 	{md5		2.0}
 	{Tk		8.5}
-	{img::png	1.3}
+	{img::png	2.0}
 	{tdom		0.8}
 	{Tclx		8.0}
 	{Signal		1.4}
@@ -244,7 +244,7 @@ proc libraryLoadFailed {library} {
 # -----------------------------
 # Load Tk ToolKit
 set T [lindex [time {
-	if {[catch {package require img::png 1.3} e]} {
+	if {[catch {package require img::png 2.0} e]} {
 		libraryLoadFailed "img::png"
 	}
 	if {[catch {package require Tk $::MIN_TCL_VER} errinfo]} {


### PR DESCRIPTION
This small fix allows the program to run under newer systems. In particular, the `tkimg` version is bumped to 2.0 and the Left/Right arrow keys in the editor now work as expected. 